### PR TITLE
[AppStore, Subscription] Add verification returning both receipt and receipt collection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in candy_check.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 #!/usr/bin/env rake
+# frozen_string_literal: true
 
 require 'bundler/gem_tasks'
 require 'rake/testtask'

--- a/candy_check.gemspec
+++ b/candy_check.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'candy_check/version'
@@ -23,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'google-api-client', '~> 0.8.6'
   spec.add_dependency 'thor',              '~> 0.19'
 
-  spec.add_development_dependency 'rubocop',         '~> 0.39'
+  spec.add_development_dependency 'rubocop',         '~> 0.41'
   spec.add_development_dependency 'inch',            '~> 0.5'
   spec.add_development_dependency 'bundler',         '~> 1.7'
   spec.add_development_dependency 'rake',            '~> 11.1'

--- a/lib/candy_check.rb
+++ b/lib/candy_check.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'candy_check/version'
 require 'candy_check/utils'
 require 'candy_check/app_store'

--- a/lib/candy_check/app_store.rb
+++ b/lib/candy_check/app_store.rb
@@ -4,6 +4,7 @@ require 'candy_check/app_store/receipt'
 require 'candy_check/app_store/receipt_collection'
 require 'candy_check/app_store/verification'
 require 'candy_check/app_store/subscription_verification'
+require 'candy_check/app_store/full_subscription_verification'
 require 'candy_check/app_store/verification_failure'
 require 'candy_check/app_store/verifier'
 

--- a/lib/candy_check/app_store.rb
+++ b/lib/candy_check/app_store.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'candy_check/app_store/client'
 require 'candy_check/app_store/config'
 require 'candy_check/app_store/receipt'

--- a/lib/candy_check/app_store/client.rb
+++ b/lib/candy_check/app_store/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'multi_json'
 require 'net/http'
 
@@ -7,7 +8,7 @@ module CandyCheck
     # servers (either sandbox or production).
     class Client
       # Mimetype for JSON objects
-      JSON_MIME_TYPE = 'application/json'.freeze
+      JSON_MIME_TYPE = 'application/json'
 
       # Initialize a new client bound to an endpoint
       # @param endpoint_url [String]

--- a/lib/candy_check/app_store/config.rb
+++ b/lib/candy_check/app_store/config.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module AppStore
     # Configure the verifier

--- a/lib/candy_check/app_store/full_subscription_verification.rb
+++ b/lib/candy_check/app_store/full_subscription_verification.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module AppStore
     # Verifies a receipt and latest_receipt_info block against a verification server.

--- a/lib/candy_check/app_store/full_subscription_verification.rb
+++ b/lib/candy_check/app_store/full_subscription_verification.rb
@@ -1,0 +1,29 @@
+module CandyCheck
+  module AppStore
+    # Verifies a receipt and latest_receipt_info block against a verification server.
+    # The call return either a struct {<FullSubscriptionInfo receipt="foo", receipt_collection="bar">} or a {VerificationFailure}
+    class FullSubscriptionVerification < CandyCheck::AppStore::Verification
+      # Performs the verification against the remote server
+      # @return [FullSubscriptionInfo] if successful
+      # @return [VerificationFailure] otherwise
+      def call!
+        verify!
+        return VerificationFailure.fetch(@response['status']) unless valid?
+        full_subscription_info
+      end
+
+      private
+
+      def full_subscription_info
+        receipt = Receipt.new(@response['receipt'])
+        receipt_collection = ReceiptCollection.new(@response['latest_receipt_info'])
+
+        OpenStruct.new(receipt: receipt, receipt_collection: receipt_collection)
+      end
+
+      def valid?
+        super && @response['latest_receipt_info']
+      end
+    end
+  end
+end

--- a/lib/candy_check/app_store/receipt.rb
+++ b/lib/candy_check/app_store/receipt.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module AppStore
     # Describes a successful response from the AppStore verification server

--- a/lib/candy_check/app_store/receipt_collection.rb
+++ b/lib/candy_check/app_store/receipt_collection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module AppStore
     # Store multiple {Receipt}s in order to perform collective operation on them

--- a/lib/candy_check/app_store/subscription_verification.rb
+++ b/lib/candy_check/app_store/subscription_verification.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module AppStore
     # Verifies a latest_receipt_info block against a verification server.

--- a/lib/candy_check/app_store/verification.rb
+++ b/lib/candy_check/app_store/verification.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module AppStore
     # Verifies a receipt block against a verification server.

--- a/lib/candy_check/app_store/verification.rb
+++ b/lib/candy_check/app_store/verification.rb
@@ -37,8 +37,12 @@ module CandyCheck
 
       private
 
+      def response_status_ok?
+        @response['status'] == STATUS_OK
+      end
+
       def valid?
-        @response && @response['status'] == STATUS_OK && @response['receipt']
+        @response && response_status_ok? && @response['receipt']
       end
 
       def verify!

--- a/lib/candy_check/app_store/verification_failure.rb
+++ b/lib/candy_check/app_store/verification_failure.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module AppStore
     # Represents a failing call against the verification server

--- a/lib/candy_check/app_store/verifier.rb
+++ b/lib/candy_check/app_store/verifier.rb
@@ -44,6 +44,16 @@ module CandyCheck
         fetch_receipt_information(receipt_data, secret)
       end
 
+      # Calls a subscription verification for the given input
+      # @param receipt_data [String] the raw data to be verified
+      # @param secret [string] the optional shared secret
+      # @return [<struct FullSubscriptionInfo receipt=<Receipt>, receipt_collection=<ReceiptCollection>>] if successful
+      # @return [VerificationFailure] otherwise
+      def verify_subscription_with_full_response(receipt_data, secret = nil)
+        @verifier = FullSubscriptionVerification
+        fetch_receipt_information(receipt_data, secret)
+      end
+
       private
 
       def fetch_receipt_information(receipt_data, secret = nil)

--- a/lib/candy_check/app_store/verifier.rb
+++ b/lib/candy_check/app_store/verifier.rb
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 module CandyCheck
   module AppStore
     # Verifies receipts against the verification servers.
     # The call return either an {Receipt} or a {VerificationFailure}
     class Verifier
       # HTTPS endpoint for production receipts
-      PRODUCTION_ENDPOINT = 'https://buy.itunes.apple.com/verifyReceipt'.freeze
+      PRODUCTION_ENDPOINT = 'https://buy.itunes.apple.com/verifyReceipt'
       # HTTPS endpoint for sandbox receipts
-      SANDBOX_ENDPOINT = 'https://sandbox.itunes.apple.com/verifyReceipt'.freeze
+      SANDBOX_ENDPOINT = 'https://sandbox.itunes.apple.com/verifyReceipt'
       # Status code from production endpoint when receiving a sandbox
       # receipt which occurs during the app's review process
       REDIRECT_TO_SANDBOX_CODE = 21_007

--- a/lib/candy_check/cli.rb
+++ b/lib/candy_check/cli.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'candy_check/cli/app'
 require 'candy_check/cli/commands'
 require 'candy_check/cli/out'

--- a/lib/candy_check/cli/app.rb
+++ b/lib/candy_check/cli/app.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'thor'
 
 module CandyCheck

--- a/lib/candy_check/cli/commands.rb
+++ b/lib/candy_check/cli/commands.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'candy_check/cli/commands/base'
 require 'candy_check/cli/commands/app_store'
 require 'candy_check/cli/commands/play_store'

--- a/lib/candy_check/cli/commands/app_store.rb
+++ b/lib/candy_check/cli/commands/app_store.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module CLI
     module Commands

--- a/lib/candy_check/cli/commands/base.rb
+++ b/lib/candy_check/cli/commands/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module CLI
     module Commands

--- a/lib/candy_check/cli/commands/play_store.rb
+++ b/lib/candy_check/cli/commands/play_store.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module CLI
     module Commands

--- a/lib/candy_check/cli/commands/version.rb
+++ b/lib/candy_check/cli/commands/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module CLI
     module Commands

--- a/lib/candy_check/cli/out.rb
+++ b/lib/candy_check/cli/out.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'pp'
 
 module CandyCheck

--- a/lib/candy_check/play_store.rb
+++ b/lib/candy_check/play_store.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'google/api_client'
 
 require 'candy_check/play_store/discovery_repository'

--- a/lib/candy_check/play_store/client.rb
+++ b/lib/candy_check/play_store/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module PlayStore
     # A client which uses the official Google API SDK to authenticate
@@ -15,13 +16,13 @@ module CandyCheck
       class DiscoveryError < RuntimeError; end
 
       # API endpoint
-      API_URL      = 'https://accounts.google.com/o/oauth2/token'.freeze
+      API_URL      = 'https://accounts.google.com/o/oauth2/token'
       # API scope for Android services
-      API_SCOPE    = 'https://www.googleapis.com/auth/androidpublisher'.freeze
+      API_SCOPE    = 'https://www.googleapis.com/auth/androidpublisher'
       # API discovery namespace
-      API_DISCOVER = 'androidpublisher'.freeze
+      API_DISCOVER = 'androidpublisher'
       # API version
-      API_VERSION  = 'v2'.freeze
+      API_VERSION  = 'v2'
 
       # Initializes a client using a configuration.
       # @param config [ClientConfig]

--- a/lib/candy_check/play_store/config.rb
+++ b/lib/candy_check/play_store/config.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module PlayStore
     # Configure the usage of the official Google API SDK client

--- a/lib/candy_check/play_store/discovery_repository.rb
+++ b/lib/candy_check/play_store/discovery_repository.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module PlayStore
     # A file-based repository to cache a local copy of the Google API

--- a/lib/candy_check/play_store/receipt.rb
+++ b/lib/candy_check/play_store/receipt.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module PlayStore
     # Describes a successful response from the Google verification server

--- a/lib/candy_check/play_store/subscription.rb
+++ b/lib/candy_check/play_store/subscription.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module PlayStore
     # Describes a succeful subscription validation

--- a/lib/candy_check/play_store/subscription_verification.rb
+++ b/lib/candy_check/play_store/subscription_verification.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module PlayStore
     # Verifies a purchase token against the Google API

--- a/lib/candy_check/play_store/verification.rb
+++ b/lib/candy_check/play_store/verification.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module PlayStore
     # Verifies a purchase token against the Google API

--- a/lib/candy_check/play_store/verification_failure.rb
+++ b/lib/candy_check/play_store/verification_failure.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module PlayStore
     # Represents a failing call against the Google API server

--- a/lib/candy_check/play_store/verifier.rb
+++ b/lib/candy_check/play_store/verifier.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module PlayStore
     # Verifies purchase tokens against the Google API.

--- a/lib/candy_check/utils.rb
+++ b/lib/candy_check/utils.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 require 'candy_check/utils/attribute_reader'
 require 'candy_check/utils/config'

--- a/lib/candy_check/utils/attribute_reader.rb
+++ b/lib/candy_check/utils/attribute_reader.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'date'
 
 module CandyCheck

--- a/lib/candy_check/utils/config.rb
+++ b/lib/candy_check/utils/config.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CandyCheck
   module Utils
     # Very basic base implementation to store and validate a configuration
@@ -5,9 +6,11 @@ module CandyCheck
       # Initializes a new configuration from a hash
       # @param attributes [Hash]
       def initialize(attributes)
-        attributes.each do |k, v|
-          instance_variable_set "@#{k}", v
-        end if attributes.is_a? Hash
+        if attributes.is_a? Hash
+          attributes.each do |k, v|
+            instance_variable_set "@#{k}", v
+          end
+        end
         validate!
       end
 

--- a/lib/candy_check/version.rb
+++ b/lib/candy_check/version.rb
@@ -1,4 +1,5 @@
+# frozen_string_literal: true
 module CandyCheck
   # The current gem's version
-  VERSION = '0.0.5'.freeze
+  VERSION = '0.0.5'
 end

--- a/spec/app_store/client_spec.rb
+++ b/spec/app_store/client_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::AppStore::Client do

--- a/spec/app_store/config_spec.rb
+++ b/spec/app_store/config_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::AppStore::Config do

--- a/spec/app_store/full_subscription_verification_spec.rb
+++ b/spec/app_store/full_subscription_verification_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::AppStore::FullSubscriptionVerification do
@@ -52,7 +53,7 @@ describe CandyCheck::AppStore::FullSubscriptionVerification do
   it 'returns a verification failure when status is 0 and latest_receipt_info is missing' do
     response = {
       'status' => 0,
-      'receipt' => { 'item_id' => 'some_id' },
+      'receipt' => { 'item_id' => 'some_id' }
     }
     with_mocked_response(response) do
       result = subject.call!
@@ -64,7 +65,7 @@ describe CandyCheck::AppStore::FullSubscriptionVerification do
   it 'returns a struct containing a Receipt and a ReceiptCollection when status is 0 and receipt and latest_receipt_info is present' do
     response = {
       'status' => 0,
-      'receipt' => {'item_id' => 'some_id'},
+      'receipt' => { 'item_id' => 'some_id' },
       'latest_receipt_info' => [
         { 'item_id' => 'some_id' },
         { 'item_id' => 'some_other_id' }
@@ -78,7 +79,6 @@ describe CandyCheck::AppStore::FullSubscriptionVerification do
       last.must_be_instance_of CandyCheck::AppStore::Receipt
       last.item_id.must_equal('some_other_id')
       result.receipt.must_be_instance_of CandyCheck::AppStore::Receipt
-
     end
   end
 

--- a/spec/app_store/full_subscription_verification_spec.rb
+++ b/spec/app_store/full_subscription_verification_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+
+describe CandyCheck::AppStore::FullSubscriptionVerification do
+  subject do
+    CandyCheck::AppStore::FullSubscriptionVerification.new(endpoint, data, secret)
+  end
+  let(:endpoint) { 'https://some.endpoint' }
+  let(:data)     { 'some_data'   }
+  let(:secret)   { 'some_secret' }
+
+  it 'returns a verification failure for status != 0' do
+    with_mocked_response('status' => 21_000) do |client, recorded|
+      result = subject.call!
+      client.receipt_data.must_equal data
+      client.secret.must_equal secret
+
+      recorded.first.must_equal [endpoint]
+
+      result.must_be_instance_of CandyCheck::AppStore::VerificationFailure
+      result.code.must_equal 21_000
+    end
+  end
+
+  it 'returns a verification failure when receipt is missing' do
+    with_mocked_response({}) do |client, recorded|
+      result = subject.call!
+      client.receipt_data.must_equal data
+      client.secret.must_equal secret
+
+      recorded.first.must_equal [endpoint]
+
+      result.must_be_instance_of CandyCheck::AppStore::VerificationFailure
+      result.code.must_equal(-1)
+    end
+  end
+
+  it 'returns a verification failure when status is 0 and receipt is missing' do
+    response = {
+      'status' => 0,
+      'latest_receipt_info' => [
+        { 'item_id' => 'some_id' },
+        { 'item_id' => 'some_other_id' }
+      ]
+    }
+    with_mocked_response(response) do
+      result = subject.call!
+      result.must_be_instance_of CandyCheck::AppStore::VerificationFailure
+      result.code.must_equal(0)
+    end
+  end
+
+  it 'returns a verification failure when status is 0 and latest_receipt_info is missing' do
+    response = {
+      'status' => 0,
+      'receipt' => { 'item_id' => 'some_id' },
+    }
+    with_mocked_response(response) do
+      result = subject.call!
+      result.must_be_instance_of CandyCheck::AppStore::VerificationFailure
+      result.code.must_equal(0)
+    end
+  end
+
+  it 'returns a struct containing a Receipt and a ReceiptCollection when status is 0 and receipt and latest_receipt_info is present' do
+    response = {
+      'status' => 0,
+      'receipt' => {'item_id' => 'some_id'},
+      'latest_receipt_info' => [
+        { 'item_id' => 'some_id' },
+        { 'item_id' => 'some_other_id' }
+      ]
+    }
+    with_mocked_response(response) do
+      result = subject.call!
+      result.receipt_collection.must_be_instance_of CandyCheck::AppStore::ReceiptCollection
+      result.receipt_collection.receipts.must_be_instance_of Array
+      last = result.receipt_collection.receipts.last
+      last.must_be_instance_of CandyCheck::AppStore::Receipt
+      last.item_id.must_equal('some_other_id')
+      result.receipt.must_be_instance_of CandyCheck::AppStore::Receipt
+
+    end
+  end
+
+  private
+
+  DummyClient = Struct.new(:response) do
+    attr_reader :receipt_data, :secret
+
+    def verify(receipt_data, secret)
+      @receipt_data = receipt_data
+      @secret = secret
+      response
+    end
+  end
+
+  def with_mocked_response(response)
+    recorded = []
+    dummy    = DummyClient.new(response)
+    stub     = proc do |*args|
+      recorded << args
+      dummy
+    end
+    CandyCheck::AppStore::Client.stub :new, stub do
+      yield dummy, recorded
+    end
+  end
+end

--- a/spec/app_store/receipt_collection_spec.rb
+++ b/spec/app_store/receipt_collection_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::AppStore::ReceiptCollection do

--- a/spec/app_store/receipt_spec.rb
+++ b/spec/app_store/receipt_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::AppStore::Receipt do

--- a/spec/app_store/subscription_verification_spec.rb
+++ b/spec/app_store/subscription_verification_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::AppStore::SubscriptionVerification do

--- a/spec/app_store/verifcation_failure_spec.rb
+++ b/spec/app_store/verifcation_failure_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::AppStore::VerificationFailure do

--- a/spec/app_store/verification_spec.rb
+++ b/spec/app_store/verification_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::AppStore::Verification do

--- a/spec/app_store/verifier_spec.rb
+++ b/spec/app_store/verifier_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::AppStore::Verifier do

--- a/spec/candy_check_spec.rb
+++ b/spec/candy_check_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck do

--- a/spec/cli/app_spec.rb
+++ b/spec/cli/app_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::CLI::App do

--- a/spec/cli/commands/app_store_spec.rb
+++ b/spec/cli/commands/app_store_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::CLI::Commands::AppStore do

--- a/spec/cli/commands/play_store_spec.rb
+++ b/spec/cli/commands/play_store_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::CLI::Commands::PlayStore do

--- a/spec/cli/commands/version_spec.rb
+++ b/spec/cli/commands/version_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::CLI::Commands::Version do

--- a/spec/cli/out_spec.rb
+++ b/spec/cli/out_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::CLI::Out do

--- a/spec/play_store/client_spec.rb
+++ b/spec/play_store/client_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::PlayStore::Client do

--- a/spec/play_store/config_spec.rb
+++ b/spec/play_store/config_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::PlayStore::Config do

--- a/spec/play_store/discovery_respository_spec.rb
+++ b/spec/play_store/discovery_respository_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::PlayStore::DiscoveryRepository do

--- a/spec/play_store/receipt_spec.rb
+++ b/spec/play_store/receipt_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::PlayStore::Receipt do
@@ -45,7 +46,7 @@ describe CandyCheck::PlayStore::Receipt do
     end
 
     it 'returns the purchased_at' do
-      expected = DateTime.new(2015, 1, 19, 14, 03, 57)
+      expected = DateTime.new(2015, 1, 19, 14, 0o3, 57)
       subject.purchased_at.must_equal expected
     end
   end

--- a/spec/play_store/subscription_spec.rb
+++ b/spec/play_store/subscription_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::PlayStore::Subscription do
@@ -46,11 +47,11 @@ describe CandyCheck::PlayStore::Subscription do
     end
 
     it 'returns the start_time_millis' do
-      subject.start_time_millis.must_equal 145_954_011_324_4
+      subject.start_time_millis.must_equal 1_459_540_113_244
     end
 
     it 'returns the expiry_time_millis' do
-      subject.expiry_time_millis.must_equal 146_213_208_861_0
+      subject.expiry_time_millis.must_equal 1_462_132_088_610
     end
 
     it 'returns the starts_at' do

--- a/spec/play_store/subscription_verification_spec.rb
+++ b/spec/play_store/subscription_verification_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::PlayStore::SubscriptionVerification do
@@ -85,8 +86,7 @@ describe CandyCheck::PlayStore::SubscriptionVerification do
   DummyGoogleSubsClient = Struct.new(:response) do
     attr_reader :package, :product_id, :token
 
-    def boot!
-    end
+    def boot!; end
 
     def verify_subscription(package, product_id, token)
       @package = package

--- a/spec/play_store/verification_failure_spec.rb
+++ b/spec/play_store/verification_failure_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::PlayStore::VerificationFailure do

--- a/spec/play_store/verification_spec.rb
+++ b/spec/play_store/verification_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::PlayStore::Verification do
@@ -69,8 +70,7 @@ describe CandyCheck::PlayStore::Verification do
   DummyGoogleClient = Struct.new(:response) do
     attr_reader :package, :product_id, :token
 
-    def boot!
-    end
+    def boot!; end
 
     def verify(package, product_id, token)
       @package = package

--- a/spec/play_store/verifier_spec.rb
+++ b/spec/play_store/verifier_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe CandyCheck::PlayStore::Verifier do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'coveralls'
 Coveralls.wear!
 


### PR DESCRIPTION
With the current verification models there is no way to get both the Receipt and the ReceiptCollection.

I'd like that in order to cut one request to apple while creating and validating a subscription.