### PR TITLE
Use lastest expired_at for AppStore receipt collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /coverage/
 .yardoc
 doc
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 /coverage/
 .yardoc
 doc
-.idea/

--- a/lib/candy_check/app_store/receipt_collection.rb
+++ b/lib/candy_check/app_store/receipt_collection.rb
@@ -10,7 +10,9 @@ module CandyCheck
       # from Apple's verification server
       # @param attributes [Array<Hash>]
       def initialize(attributes)
-        @receipts = attributes.map { |r| Receipt.new(r) }
+        @receipts = attributes.map {|r| Receipt.new(r) }.sort{ |a, b|
+          a.purchase_date - b.purchase_date
+        }
       end
 
       # Check if the latest expiration date is passed

--- a/spec/app_store/receipt_collection_spec.rb
+++ b/spec/app_store/receipt_collection_spec.rb
@@ -8,10 +8,12 @@ describe CandyCheck::AppStore::ReceiptCollection do
       [{
         'expires_date' => '2014-04-15 12:52:40 Etc/GMT',
         'expires_date_pst' => '2014-04-15 05:52:40 America/Los_Angeles',
+        'purchase_date' => '2014-04-14 12:52:40 Etc/GMT',
         'is_trial_period' => 'false'
       }, {
         'expires_date' => '2015-04-15 12:52:40 Etc/GMT',
         'expires_date_pst' => '2015-04-15 05:52:40 America/Los_Angeles',
+        'purchase_date' => '2015-04-14 12:52:40 Etc/GMT',
         'is_trial_period' => 'false'
       }]
     end
@@ -42,16 +44,40 @@ describe CandyCheck::AppStore::ReceiptCollection do
     end
   end
 
+  describe 'unordered receipts' do
+    let(:attributes) do
+      [{
+           'expires_date' => '2015-04-15 12:52:40 Etc/GMT',
+           'expires_date_pst' => '2015-04-15 05:52:40 America/Los_Angeles',
+           'purchase_date' => '2015-04-14 12:52:40 Etc/GMT',
+           'is_trial_period' => 'false'
+       }, {
+           'expires_date' => '2014-04-15 12:52:40 Etc/GMT',
+           'expires_date_pst' => '2014-04-15 05:52:40 America/Los_Angeles',
+           'purchase_date' => '2014-04-14 12:52:40 Etc/GMT',
+           'is_trial_period' => 'false'
+       }]
+    end
+
+    it 'the expires date is the latest one in time' do
+      expected = DateTime.new(2015, 4, 15, 12, 52, 40)
+      subject.expires_at.must_equal expected
+    end
+
+  end
+
   describe 'unexpired trial subscription' do
     two_days_from_now = DateTime.now + 2
 
     let(:attributes) do
       [{
         'expires_date' => '2016-04-15 12:52:40 Etc/GMT',
+        'purchase_date' => '2016-04-15 12:52:40 Etc/GMT',
         'is_trial_period' => 'true'
       }, {
         'expires_date' =>
           two_days_from_now.strftime('%Y-%m-%d %H:%M:%S Etc/GMT'),
+        'purchase_date' => '2016-04-15 12:52:40 Etc/GMT',
         'is_trial_period' => 'true'
       }]
     end
@@ -68,4 +94,5 @@ describe CandyCheck::AppStore::ReceiptCollection do
       subject.overdue_days.must_equal(-2)
     end
   end
+
 end

--- a/spec/app_store/subscription_verification_spec.rb
+++ b/spec/app_store/subscription_verification_spec.rb
@@ -38,8 +38,8 @@ describe CandyCheck::AppStore::SubscriptionVerification do
     response = {
       'status' => 0,
       'latest_receipt_info' => [
-        { 'item_id' => 'some_id' },
-        { 'item_id' => 'some_other_id' }
+        { 'item_id' => 'some_id', 'purchase_date' => '2016-04-15 12:52:40 Etc/GMT' },
+        { 'item_id' => 'some_other_id', 'purchase_date' => '2016-04-15 12:52:40 Etc/GMT' }
       ]
     }
     with_mocked_response(response) do


### PR DESCRIPTION
This is basically only a rebase of @sonxurxo's #39.
