### PR TITLE
Amend logic for obtaining todays date

### DIFF
--- a/lib/candy_check/play_store/subscription_purchases/subscription_purchase.rb
+++ b/lib/candy_check/play_store/subscription_purchases/subscription_purchase.rb
@@ -66,7 +66,7 @@ module CandyCheck
         # Get number of overdue days. If this is negative, it is not overdue.
         # @return [Integer]
         def overdue_days
-          (Date.today - expires_at.to_date).to_i
+          (Time.now.utc.to_date - expires_at.to_date).to_i
         end
 
         # Get the auto renewal status as given by Google


### PR DESCRIPTION
Porting the changes of @ricky-crichq to the new Google API

`Date.today` respects the system time zone when we should be using UTC.
This change returns the current day in the UTC time zone.

Candy Check issue: https://github.com/jnbt/candy_check/issues/20