### PR TITLE
Update to use latest_receipt_info instead of receipt

### DIFF
--- a/lib/candy_check/app_store/receipt.rb
+++ b/lib/candy_check/app_store/receipt.rb
@@ -7,11 +7,16 @@ module CandyCheck
       # @return [Hash] the raw attributes returned from the server
       attr_reader :attributes
 
+      # @return [Boolean] true if this appears to be an old-style receipt,
+      #   false otherwise
+      attr_reader :old_receipt
+
       # Initializes a new instance which bases on a JSON result
       # from Apple's verification server
       # @param attributes [Hash]
       def initialize(attributes)
         @attributes = attributes
+        @old_receipt = !attributes.bid.nil?
       end
 
       # In most cases a receipt is a valid transaction except when the
@@ -34,28 +39,10 @@ module CandyCheck
         read('original_transaction_id')
       end
 
-      # The version number for the app
-      # @return [String]
-      def app_version
-        read('bvrs')
-      end
-
-      # The app's bundle identifier
-      # @return [String]
-      def bundle_identifier
-        read('bid')
-      end
-
       # The app's identifier of the product (SKU)
       # @return [String]
       def product_id
         read('product_id')
-      end
-
-      # The app's item id of the product
-      # @return [String]
-      def item_id
-        read('item_id')
       end
 
       # The quantity of the product

--- a/lib/candy_check/app_store/receipt.rb
+++ b/lib/candy_check/app_store/receipt.rb
@@ -75,7 +75,7 @@ module CandyCheck
       # The date of a subscription's expiration
       # @return [DateTime]
       def expires_date
-        read_datetime_from_string('expires_date')
+        @old_receipt ? Time.at(@attributes['expires_date'].to_i / 1000) : read_datetime_from_string('expires_date')
       end
 
       # rubocop:disable PredicateName

--- a/lib/candy_check/app_store/verification.rb
+++ b/lib/candy_check/app_store/verification.rb
@@ -29,7 +29,7 @@ module CandyCheck
       def call!
         verify!
         if valid?
-          Receipt.new(@response['receipt'])
+          Receipt.new(@response['latest_receipt_info'])
         else
           VerificationFailure.fetch(@response['status'])
         end

--- a/spec/app_store/receipt_spec.rb
+++ b/spec/app_store/receipt_spec.rb
@@ -34,24 +34,12 @@ describe CandyCheck::AppStore::Receipt do
       subject.valid?.must_be_true
     end
 
-    it 'returns the item\'s id' do
-      subject.item_id.must_equal 'some_item_id'
-    end
-
     it 'returns the item\'s product_id' do
       subject.product_id.must_equal 'some_product'
     end
 
     it 'returns the quantity' do
       subject.quantity.must_equal 1
-    end
-
-    it 'returns the app version' do
-      subject.app_version.must_equal '2.0'
-    end
-
-    it 'returns the bundle identifier' do
-      subject.bundle_identifier.must_equal 'some.test.app'
     end
 
     it 'returns the purchase date' do


### PR DESCRIPTION
This requires many fewer changes than trying to adapt receipt to work
with the new version of apple receipts; just drop some fields