### PR TITLE
Update candy_check.gemspec

### DIFF
--- a/candy_check.gemspec
+++ b/candy_check.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "google-api-client", "~> 0.43.0"
   spec.add_dependency "multi_json", "~> 1.10"
-  spec.add_dependency "thor", "~> 0.19"
+  spec.add_dependency "thor"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "coveralls", "~> 0.8"


### PR DESCRIPTION
Hi,

This PR relaxes the constraint on Thor's version, allowing for example to update to Rails 6.1.