### PR TITLE
Resolve test warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /coverage/
 .yardoc
 doc
+vendor/bundle

--- a/spec/app_store/client_spec.rb
+++ b/spec/app_store/client_spec.rb
@@ -39,7 +39,7 @@ describe CandyCheck::AppStore::Client do
           body: response
         )
       result = subject.verify(receipt_data)
-      result.must_equal expected
+      _(result).must_equal expected
     end
 
     it 'sends JSON and parses the JSON response with a secret' do
@@ -54,7 +54,7 @@ describe CandyCheck::AppStore::Client do
           body: response
         )
       result = subject.verify(receipt_data, password)
-      result.must_equal expected
+      _(result).must_equal expected
     end
   end
 

--- a/spec/app_store/config_spec.rb
+++ b/spec/app_store/config_spec.rb
@@ -20,7 +20,7 @@ describe CandyCheck::AppStore::Config do
       other = CandyCheck::AppStore::Config.new(
         environment: :production
       )
-      other.production?.must_be_true
+      _(other.production?).must_be_true
     end
   end
 

--- a/spec/app_store/config_spec.rb
+++ b/spec/app_store/config_spec.rb
@@ -15,7 +15,7 @@ describe CandyCheck::AppStore::Config do
     end
 
     it 'checks for production?' do
-      subject.production?.must_be_false
+      _(subject.production?).must_be_false
 
       other = CandyCheck::AppStore::Config.new(
         environment: :production

--- a/spec/app_store/config_spec.rb
+++ b/spec/app_store/config_spec.rb
@@ -11,7 +11,7 @@ describe CandyCheck::AppStore::Config do
     end
 
     it 'returns environment' do
-      subject.environment.must_equal :sandbox
+      _(subject.environment).must_equal :sandbox
     end
 
     it 'checks for production?' do

--- a/spec/app_store/config_spec.rb
+++ b/spec/app_store/config_spec.rb
@@ -30,12 +30,12 @@ describe CandyCheck::AppStore::Config do
     end
 
     it 'needs an environment' do
-      proc { subject }.must_raise ArgumentError
+      _(proc { subject }).must_raise ArgumentError
     end
 
     it 'needs an included environment' do
       attributes[:environment] = :invalid
-      proc { subject }.must_raise ArgumentError
+      _(proc { subject }).must_raise ArgumentError
     end
   end
 end

--- a/spec/app_store/receipt_collection_spec.rb
+++ b/spec/app_store/receipt_collection_spec.rb
@@ -28,7 +28,7 @@ describe CandyCheck::AppStore::ReceiptCollection do
 
     it 'has positive overdue days' do
       overdue = subject.overdue_days
-      overdue.must_be_instance_of Fixnum
+      _(overdue).must_be_instance_of Fixnum
       assert overdue > 0
     end
 

--- a/spec/app_store/receipt_collection_spec.rb
+++ b/spec/app_store/receipt_collection_spec.rb
@@ -23,7 +23,7 @@ describe CandyCheck::AppStore::ReceiptCollection do
     end
 
     it 'is not a trial' do
-      subject.trial?.must_be_false
+      _(subject.trial?).must_be_false
     end
 
     it 'has positive overdue days' do
@@ -83,7 +83,7 @@ describe CandyCheck::AppStore::ReceiptCollection do
     end
 
     it 'has not expired' do
-      subject.expired?.must_be_false
+      _(subject.expired?).must_be_false
     end
 
     it 'it is a trial' do

--- a/spec/app_store/receipt_collection_spec.rb
+++ b/spec/app_store/receipt_collection_spec.rb
@@ -19,7 +19,7 @@ describe CandyCheck::AppStore::ReceiptCollection do
     end
 
     it 'is expired' do
-      subject.expired?.must_be_true
+      _(subject.expired?).must_be_true
     end
 
     it 'is not a trial' do
@@ -39,7 +39,7 @@ describe CandyCheck::AppStore::ReceiptCollection do
 
     it 'is expired? at same pointin time' do
       Timecop.freeze(Time.utc(2015, 4, 15, 12, 52, 40)) do
-        subject.expired?.must_be_true
+        _(subject.expired?).must_be_true
       end
     end
   end
@@ -87,7 +87,7 @@ describe CandyCheck::AppStore::ReceiptCollection do
     end
 
     it 'it is a trial' do
-      subject.trial?.must_be_true
+      _(subject.trial?).must_be_true
     end
 
     it 'expires in two days' do

--- a/spec/app_store/receipt_collection_spec.rb
+++ b/spec/app_store/receipt_collection_spec.rb
@@ -34,7 +34,7 @@ describe CandyCheck::AppStore::ReceiptCollection do
 
     it 'has a last expires date' do
       expected = DateTime.new(2015, 4, 15, 12, 52, 40)
-      subject.expires_at.must_equal expected
+      _(subject.expires_at).must_equal expected
     end
 
     it 'is expired? at same pointin time' do
@@ -61,7 +61,7 @@ describe CandyCheck::AppStore::ReceiptCollection do
 
     it 'the expires date is the latest one in time' do
       expected = DateTime.new(2015, 4, 15, 12, 52, 40)
-      subject.expires_at.must_equal expected
+      _(subject.expires_at).must_equal expected
     end
 
   end
@@ -91,7 +91,7 @@ describe CandyCheck::AppStore::ReceiptCollection do
     end
 
     it 'expires in two days' do
-      subject.overdue_days.must_equal(-2)
+      _(subject.overdue_days).must_equal(-2)
     end
   end
 

--- a/spec/app_store/receipt_spec.rb
+++ b/spec/app_store/receipt_spec.rb
@@ -35,41 +35,41 @@ describe CandyCheck::AppStore::Receipt do
     end
 
     it 'returns the item\'s id' do
-      subject.item_id.must_equal 'some_item_id'
+      _(subject.item_id).must_equal 'some_item_id'
     end
 
     it 'returns the item\'s product_id' do
-      subject.product_id.must_equal 'some_product'
+      _(subject.product_id).must_equal 'some_product'
     end
 
     it 'returns the quantity' do
-      subject.quantity.must_equal 1
+      _(subject.quantity).must_equal 1
     end
 
     it 'returns the app version' do
-      subject.app_version.must_equal '2.0'
+      _(subject.app_version).must_equal '2.0'
     end
 
     it 'returns the bundle identifier' do
-      subject.bundle_identifier.must_equal 'some.test.app'
+      _(subject.bundle_identifier).must_equal 'some.test.app'
     end
 
     it 'returns the purchase date' do
       expected = DateTime.new(2015, 1, 9, 11, 40, 46)
-      subject.purchase_date.must_equal expected
+      _(subject.purchase_date).must_equal expected
     end
 
     it 'returns the original purchase date' do
       expected = DateTime.new(2015, 1, 8, 11, 40, 46)
-      subject.original_purchase_date.must_equal expected
+      _(subject.original_purchase_date).must_equal expected
     end
 
     it 'returns the transaction id' do
-      subject.transaction_id.must_equal 'some_transaction_id'
+      _(subject.transaction_id).must_equal 'some_transaction_id'
     end
 
     it 'returns the original transaction id' do
-      subject.original_transaction_id.must_equal 'some_original_transaction_id'
+      _(subject.original_transaction_id).must_equal 'some_original_transaction_id'
     end
 
     it 'return nil for cancellation date' do
@@ -82,7 +82,7 @@ describe CandyCheck::AppStore::Receipt do
 
     it 'returns the subscription expiration date' do
       expected = DateTime.new(2016, 6, 9, 13, 59, 40)
-      subject.expires_date.must_equal expected
+      _(subject.expires_date).must_equal expected
     end
 
     it 'returns the trial status' do
@@ -101,7 +101,7 @@ describe CandyCheck::AppStore::Receipt do
 
     it 'return nil for cancellation date' do
       expected = DateTime.new(2015, 1, 12, 11, 40, 46)
-      subject.cancellation_date.must_equal expected
+      _(subject.cancellation_date).must_equal expected
     end
   end
 end

--- a/spec/app_store/receipt_spec.rb
+++ b/spec/app_store/receipt_spec.rb
@@ -73,7 +73,7 @@ describe CandyCheck::AppStore::Receipt do
     end
 
     it 'return nil for cancellation date' do
-      subject.cancellation_date.must_be_nil
+      _(subject.cancellation_date).must_be_nil
     end
 
     it 'returns raw attributes' do

--- a/spec/app_store/receipt_spec.rb
+++ b/spec/app_store/receipt_spec.rb
@@ -86,7 +86,7 @@ describe CandyCheck::AppStore::Receipt do
     end
 
     it 'returns the trial status' do
-      subject.is_trial_period.must_be_false
+      _(subject.is_trial_period).must_be_false
     end
   end
 
@@ -96,7 +96,7 @@ describe CandyCheck::AppStore::Receipt do
     end
 
     it 'isn\'t valid' do
-      subject.valid?.must_be_false
+      _(subject.valid?).must_be_false
     end
 
     it 'return nil for cancellation date' do

--- a/spec/app_store/receipt_spec.rb
+++ b/spec/app_store/receipt_spec.rb
@@ -31,7 +31,7 @@ describe CandyCheck::AppStore::Receipt do
 
   describe 'valid transaction' do
     it 'is valid' do
-      subject.valid?.must_be_true
+      _(subject.valid?).must_be_true
     end
 
     it 'returns the item\'s id' do

--- a/spec/app_store/receipt_spec.rb
+++ b/spec/app_store/receipt_spec.rb
@@ -77,7 +77,7 @@ describe CandyCheck::AppStore::Receipt do
     end
 
     it 'returns raw attributes' do
-      subject.attributes.must_be_same_as attributes
+      _(subject.attributes).must_be_same_as attributes
     end
 
     it 'returns the subscription expiration date' do

--- a/spec/app_store/subscription_verification_spec.rb
+++ b/spec/app_store/subscription_verification_spec.rb
@@ -11,26 +11,26 @@ describe CandyCheck::AppStore::SubscriptionVerification do
   it 'returns a verification failure for status != 0' do
     with_mocked_response('status' => 21_000) do |client, recorded|
       result = subject.call!
-      client.receipt_data.must_equal data
-      client.secret.must_equal secret
+      _(client.receipt_data).must_equal data
+      _(client.secret).must_equal secret
 
-      recorded.first.must_equal [endpoint]
+      _(recorded.first).must_equal [endpoint]
 
       _(result).must_be_instance_of CandyCheck::AppStore::VerificationFailure
-      result.code.must_equal 21_000
+      _(result.code).must_equal 21_000
     end
   end
 
   it 'returns a verification failure when receipt is missing' do
     with_mocked_response({}) do |client, recorded|
       result = subject.call!
-      client.receipt_data.must_equal data
-      client.secret.must_equal secret
+      _(client.receipt_data).must_equal data
+      _(client.secret).must_equal secret
 
-      recorded.first.must_equal [endpoint]
+      _(recorded.first).must_equal [endpoint]
 
       _(result).must_be_instance_of CandyCheck::AppStore::VerificationFailure
-      result.code.must_equal(-1)
+      _(result.code).must_equal(-1)
     end
   end
 
@@ -46,10 +46,10 @@ describe CandyCheck::AppStore::SubscriptionVerification do
       result = subject.call!
       _(result).must_be_instance_of CandyCheck::AppStore::ReceiptCollection
       _(result.receipts).must_be_instance_of Array
-      result.receipts.size.must_equal(2)
+      _(result.receipts.size).must_equal(2)
       last = result.receipts.last
       _(last).must_be_instance_of CandyCheck::AppStore::Receipt
-      last.item_id.must_equal('some_other_id')
+      _(last.item_id).must_equal('some_other_id')
     end
   end
 
@@ -77,10 +77,10 @@ describe CandyCheck::AppStore::SubscriptionVerification do
         result = subject.call!
         _(result).must_be_instance_of CandyCheck::AppStore::ReceiptCollection
         _(result.receipts).must_be_instance_of Array
-        result.receipts.size.must_equal(2)
+        _(result.receipts.size).must_equal(2)
         last = result.receipts.last
         _(last).must_be_instance_of CandyCheck::AppStore::Receipt
-        last.item_id.must_equal('some_other_id')
+        _(last.item_id).must_equal('some_other_id')
       end
     end
   end

--- a/spec/app_store/subscription_verification_spec.rb
+++ b/spec/app_store/subscription_verification_spec.rb
@@ -16,7 +16,7 @@ describe CandyCheck::AppStore::SubscriptionVerification do
 
       recorded.first.must_equal [endpoint]
 
-      result.must_be_instance_of CandyCheck::AppStore::VerificationFailure
+      _(result).must_be_instance_of CandyCheck::AppStore::VerificationFailure
       result.code.must_equal 21_000
     end
   end
@@ -29,7 +29,7 @@ describe CandyCheck::AppStore::SubscriptionVerification do
 
       recorded.first.must_equal [endpoint]
 
-      result.must_be_instance_of CandyCheck::AppStore::VerificationFailure
+      _(result).must_be_instance_of CandyCheck::AppStore::VerificationFailure
       result.code.must_equal(-1)
     end
   end
@@ -44,11 +44,11 @@ describe CandyCheck::AppStore::SubscriptionVerification do
     }
     with_mocked_response(response) do
       result = subject.call!
-      result.must_be_instance_of CandyCheck::AppStore::ReceiptCollection
-      result.receipts.must_be_instance_of Array
+      _(result).must_be_instance_of CandyCheck::AppStore::ReceiptCollection
+      _(result.receipts).must_be_instance_of Array
       result.receipts.size.must_equal(2)
       last = result.receipts.last
-      last.must_be_instance_of CandyCheck::AppStore::Receipt
+      _(last).must_be_instance_of CandyCheck::AppStore::Receipt
       last.item_id.must_equal('some_other_id')
     end
   end
@@ -75,11 +75,11 @@ describe CandyCheck::AppStore::SubscriptionVerification do
       }
       with_mocked_response(response) do
         result = subject.call!
-        result.must_be_instance_of CandyCheck::AppStore::ReceiptCollection
-        result.receipts.must_be_instance_of Array
+        _(result).must_be_instance_of CandyCheck::AppStore::ReceiptCollection
+        _(result.receipts).must_be_instance_of Array
         result.receipts.size.must_equal(2)
         last = result.receipts.last
-        last.must_be_instance_of CandyCheck::AppStore::Receipt
+        _(last).must_be_instance_of CandyCheck::AppStore::Receipt
         last.item_id.must_equal('some_other_id')
       end
     end

--- a/spec/app_store/verifcation_failure_spec.rb
+++ b/spec/app_store/verifcation_failure_spec.rb
@@ -10,7 +10,7 @@ describe CandyCheck::AppStore::VerificationFailure do
     known.each do |code|
       got = subject.fetch(code)
       got.code.must_equal code
-      got.message.wont_equal 'Unknown error'
+      _(got.message).wont_equal 'Unknown error'
     end
   end
 

--- a/spec/app_store/verifcation_failure_spec.rb
+++ b/spec/app_store/verifcation_failure_spec.rb
@@ -9,20 +9,20 @@ describe CandyCheck::AppStore::VerificationFailure do
   it 'fetched an failure with message for every known code' do
     known.each do |code|
       got = subject.fetch(code)
-      got.code.must_equal code
+      _(got.code).must_equal code
       _(got.message).wont_equal 'Unknown error'
     end
   end
 
   it 'fetched an failure for unknown codes' do
     got = subject.fetch(1234)
-    got.code.must_equal 1234
-    got.message.must_equal 'Unknown error'
+    _(got.code).must_equal 1234
+    _(got.message).must_equal 'Unknown error'
   end
 
   it 'fetched an failure for nil code' do
     got = subject.fetch(nil)
-    got.code.must_equal(-1)
-    got.message.must_equal 'Unknown error'
+    _(got.code).must_equal(-1)
+    _(got.message).must_equal 'Unknown error'
   end
 end

--- a/spec/app_store/verification_spec.rb
+++ b/spec/app_store/verification_spec.rb
@@ -9,26 +9,26 @@ describe CandyCheck::AppStore::Verification do
   it 'returns a verification failure for status != 0' do
     with_mocked_response('status' => 21_000) do |client, recorded|
       result = subject.call!
-      client.receipt_data.must_equal data
-      client.secret.must_equal secret
+      _(client.receipt_data).must_equal data
+      _(client.secret).must_equal secret
 
-      recorded.first.must_equal [endpoint]
+      _(recorded.first).must_equal [endpoint]
 
       _(result).must_be_instance_of CandyCheck::AppStore::VerificationFailure
-      result.code.must_equal 21_000
+      _(result.code).must_equal 21_000
     end
   end
 
   it 'returns a verification failure when receipt is missing' do
     with_mocked_response({}) do |client, recorded|
       result = subject.call!
-      client.receipt_data.must_equal data
-      client.secret.must_equal secret
+      _(client.receipt_data).must_equal data
+      _(client.secret).must_equal secret
 
-      recorded.first.must_equal [endpoint]
+      _(recorded.first).must_equal [endpoint]
 
       _(result).must_be_instance_of CandyCheck::AppStore::VerificationFailure
-      result.code.must_equal(-1)
+      _(result.code).must_equal(-1)
     end
   end
 
@@ -37,7 +37,7 @@ describe CandyCheck::AppStore::Verification do
     with_mocked_response(response) do
       result = subject.call!
       _(result).must_be_instance_of CandyCheck::AppStore::Receipt
-      result.item_id.must_equal('some_id')
+      _(result.item_id).must_equal('some_id')
     end
   end
 

--- a/spec/app_store/verification_spec.rb
+++ b/spec/app_store/verification_spec.rb
@@ -14,7 +14,7 @@ describe CandyCheck::AppStore::Verification do
 
       recorded.first.must_equal [endpoint]
 
-      result.must_be_instance_of CandyCheck::AppStore::VerificationFailure
+      _(result).must_be_instance_of CandyCheck::AppStore::VerificationFailure
       result.code.must_equal 21_000
     end
   end
@@ -27,7 +27,7 @@ describe CandyCheck::AppStore::Verification do
 
       recorded.first.must_equal [endpoint]
 
-      result.must_be_instance_of CandyCheck::AppStore::VerificationFailure
+      _(result).must_be_instance_of CandyCheck::AppStore::VerificationFailure
       result.code.must_equal(-1)
     end
   end
@@ -36,7 +36,7 @@ describe CandyCheck::AppStore::Verification do
     response = { 'status' => 0, 'receipt' => { 'item_id' => 'some_id' } }
     with_mocked_response(response) do
       result = subject.call!
-      result.must_be_instance_of CandyCheck::AppStore::Receipt
+      _(result).must_be_instance_of CandyCheck::AppStore::Receipt
       result.item_id.must_equal('some_id')
     end
   end

--- a/spec/app_store/verifier_spec.rb
+++ b/spec/app_store/verifier_spec.rb
@@ -18,7 +18,7 @@ describe CandyCheck::AppStore::Verifier do
   end
 
   it 'holds the config' do
-    subject.config.must_be_same_as config
+    _(subject.config).must_be_same_as config
   end
 
   describe 'sandbox' do
@@ -26,7 +26,7 @@ describe CandyCheck::AppStore::Verifier do
 
     it 'uses sandbox endpoint without retry on success' do
       with_mocked_verifier(receipt) do
-        subject.verify(data, secret).must_be_same_as receipt
+        _(subject.verify(data, secret)).must_be_same_as receipt
         assert_recorded([sandbox_endpoint, data, secret])
       end
     end
@@ -34,7 +34,7 @@ describe CandyCheck::AppStore::Verifier do
     it 'only uses sandbox endpoint for normal failures' do
       failure = get_failure(21_000)
       with_mocked_verifier(failure) do
-        subject.verify(data, secret).must_be_same_as failure
+        _(subject.verify(data, secret)).must_be_same_as failure
         assert_recorded([sandbox_endpoint, data, secret])
       end
     end
@@ -42,7 +42,7 @@ describe CandyCheck::AppStore::Verifier do
     it 'retries production endpoint for redirect error' do
       failure = get_failure(21_008)
       with_mocked_verifier(failure, receipt) do
-        subject.verify(data, secret).must_be_same_as receipt
+        _(subject.verify(data, secret)).must_be_same_as receipt
         assert_recorded(
           [sandbox_endpoint, data, secret],
           [production_endpoint, data, secret]
@@ -56,7 +56,7 @@ describe CandyCheck::AppStore::Verifier do
 
     it 'uses production endpoint without retry on success' do
       with_mocked_verifier(receipt) do
-        subject.verify(data, secret).must_be_same_as receipt
+        _(subject.verify(data, secret)).must_be_same_as receipt
         assert_recorded([production_endpoint, data, secret])
       end
     end
@@ -64,7 +64,7 @@ describe CandyCheck::AppStore::Verifier do
     it 'only uses production endpoint for normal failures' do
       failure = get_failure(21_000)
       with_mocked_verifier(failure) do
-        subject.verify(data, secret).must_be_same_as failure
+        _(subject.verify(data, secret)).must_be_same_as failure
         assert_recorded([production_endpoint, data, secret])
       end
     end
@@ -72,7 +72,7 @@ describe CandyCheck::AppStore::Verifier do
     it 'retries production endpoint for redirect error' do
       failure = get_failure(21_007)
       with_mocked_verifier(failure, receipt) do
-        subject.verify(data, secret).must_be_same_as receipt
+        _(subject.verify(data, secret)).must_be_same_as receipt
         assert_recorded(
           [production_endpoint, data, secret],
           [sandbox_endpoint, data, secret]
@@ -86,9 +86,9 @@ describe CandyCheck::AppStore::Verifier do
 
     it 'uses production endpoint without retry on success' do
       with_mocked_verifier(receipt_collection) do
-        subject.verify_subscription(
+        _(subject.verify_subscription(
           data, secret
-        ).must_be_same_as receipt_collection
+        )).must_be_same_as receipt_collection
         assert_recorded([production_endpoint, data, secret, nil])
       end
     end
@@ -96,7 +96,7 @@ describe CandyCheck::AppStore::Verifier do
     it 'only uses production endpoint for normal failures' do
       failure = get_failure(21_000)
       with_mocked_verifier(failure) do
-        subject.verify_subscription(data, secret).must_be_same_as failure
+        _(subject.verify_subscription(data, secret)).must_be_same_as failure
         assert_recorded([production_endpoint, data, secret, nil])
       end
     end
@@ -104,7 +104,7 @@ describe CandyCheck::AppStore::Verifier do
     it 'retries production endpoint for redirect error' do
       failure = get_failure(21_007)
       with_mocked_verifier(failure, receipt) do
-        subject.verify_subscription(data, secret).must_be_same_as receipt
+        _(subject.verify_subscription(data, secret)).must_be_same_as receipt
         assert_recorded(
           [production_endpoint, data, secret, nil],
           [sandbox_endpoint, data, secret, nil]
@@ -115,9 +115,9 @@ describe CandyCheck::AppStore::Verifier do
     it 'passed the product_ids' do
       product_ids = ['product_1']
       with_mocked_verifier(receipt_collection) do
-        subject.verify_subscription(
+        _(subject.verify_subscription(
           data, secret, product_ids
-        ).must_be_same_as receipt_collection
+        )).must_be_same_as receipt_collection
         assert_recorded([production_endpoint, data, secret, product_ids])
       end
     end

--- a/spec/app_store/verifier_spec.rb
+++ b/spec/app_store/verifier_spec.rb
@@ -137,7 +137,7 @@ describe CandyCheck::AppStore::Verifier do
   end
 
   def assert_recorded(*calls)
-    @recorded.must_equal calls
+    _(@recorded).must_equal calls
   end
 
   def get_failure(code)

--- a/spec/candy_check_spec.rb
+++ b/spec/candy_check_spec.rb
@@ -4,6 +4,6 @@ describe CandyCheck do
   subject { CandyCheck }
 
   it "has a version" do
-    subject::VERSION.wont_be_nil
+    _(subject::VERSION).wont_be_nil
   end
 end

--- a/spec/cli/app_spec.rb
+++ b/spec/cli/app_spec.rb
@@ -5,22 +5,22 @@ describe CandyCheck::CLI::App do
 
   it 'supports the version command' do
     stub_command(CandyCheck::CLI::Commands::Version) do
-      subject.version.must_equal :stubbed
+      _(subject.version).must_equal :stubbed
       @arguments.must_be_empty
     end
   end
 
   it 'supports the app_store command' do
     stub_command(CandyCheck::CLI::Commands::AppStore) do
-      subject.app_store('receipt').must_equal :stubbed
-      @arguments.must_equal ['receipt', {}]
+      _(subject.app_store('receipt')).must_equal :stubbed
+      _(@arguments).must_equal ['receipt', {}]
     end
   end
 
   it 'supports the play_store command' do
     stub_command(CandyCheck::CLI::Commands::PlayStore) do
-      subject.play_store('package', 'id', 'token').must_equal :stubbed
-      @arguments.must_equal ['package', 'id', 'token', {}]
+      _(subject.play_store('package', 'id', 'token')).must_equal :stubbed
+      _(@arguments).must_equal ['package', 'id', 'token', {}]
     end
   end
 

--- a/spec/cli/app_spec.rb
+++ b/spec/cli/app_spec.rb
@@ -6,7 +6,7 @@ describe CandyCheck::CLI::App do
   it 'supports the version command' do
     stub_command(CandyCheck::CLI::Commands::Version) do
       _(subject.version).must_equal :stubbed
-      @arguments.must_be_empty
+      _(@arguments).must_be_empty
     end
   end
 

--- a/spec/cli/commands/app_store_spec.rb
+++ b/spec/cli/commands/app_store_spec.rb
@@ -22,9 +22,9 @@ describe CandyCheck::CLI::Commands::AppStore do
 
   describe 'default' do
     it 'uses the receipt and the options' do
-      @verifier.config.environment.must_equal :sandbox
-      @verifier.arguments.must_equal [receipt, nil]
-      out.must_be 'Hash:', result: :stubbed
+      _(@verifier.config.environment).must_equal :sandbox
+      _(@verifier.arguments).must_equal [receipt, nil]
+      _(out.lines).must_equal ['Hash:', { result: :stubbed }]
     end
   end
 
@@ -37,9 +37,9 @@ describe CandyCheck::CLI::Commands::AppStore do
     end
 
     it 'uses the secret for verification' do
-      @verifier.config.environment.must_equal :production
-      @verifier.arguments.must_equal [receipt, 'notasecret']
-      out.must_be 'Hash:', result: :stubbed
+      _(@verifier.config.environment).must_equal :production
+      _(@verifier.arguments).must_equal [receipt, 'notasecret']
+      _(out.lines).must_equal ['Hash:', { result: :stubbed }]
     end
   end
 

--- a/spec/cli/commands/version_spec.rb
+++ b/spec/cli/commands/version_spec.rb
@@ -6,6 +6,6 @@ describe CandyCheck::CLI::Commands::Version do
 
   it 'prints the gem\'s version' do
     run_command!
-    out.must_be CandyCheck::VERSION
+    _(out.lines).must_equal [CandyCheck::VERSION]
   end
 end

--- a/spec/cli/out_spec.rb
+++ b/spec/cli/out_spec.rb
@@ -16,7 +16,7 @@ describe CandyCheck::CLI::Out do
     subject.print 'some text'
     subject.print 'another line'
     close
-    out.readlines.must_equal [
+    _(out.readlines).must_equal [
       "some text\n",
       "another line\n"
     ]
@@ -26,7 +26,7 @@ describe CandyCheck::CLI::Out do
     subject.pretty dummy: 1
     subject.pretty [1, 2, 3]
     close
-    out.readlines.must_equal [
+    _(out.readlines).must_equal [
       "{:dummy=>1}\n",
       "[1, 2, 3]\n"
     ]

--- a/spec/cli/out_spec.rb
+++ b/spec/cli/out_spec.rb
@@ -5,11 +5,11 @@ describe CandyCheck::CLI::Out do
   let(:out) { StringIO.new }
 
   it 'defaults to use STDOUT' do
-    CandyCheck::CLI::Out.new.out.must_be_same_as $stdout
+    _(CandyCheck::CLI::Out.new.out).must_be_same_as $stdout
   end
 
   it 'holds the outlet' do
-    subject.out.must_be_same_as out
+    _(subject.out).must_be_same_as out
   end
 
   it 'prints to outlet' do

--- a/spec/play_store/acknowledger_spec.rb
+++ b/spec/play_store/acknowledger_spec.rb
@@ -16,7 +16,7 @@ describe CandyCheck::PlayStore::Acknowledger do
         result = subject.acknowledge_product_purchase(package_name: package_name, product_id: product_id, token: token)
 
         result.must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
-        result.acknowledged?.must_be_true
+        _(result.acknowledged?).must_be_true
         result.error.must_be_nil
       end
     end

--- a/spec/play_store/acknowledger_spec.rb
+++ b/spec/play_store/acknowledger_spec.rb
@@ -27,7 +27,7 @@ describe CandyCheck::PlayStore::Acknowledger do
         result = subject.acknowledge_product_purchase(package_name: package_name, product_id: product_id, token: token)
 
         result.must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
-        result.acknowledged?.must_be_false
+        _(result.acknowledged?).must_be_false
         result.error[:body].must_equal(error_body)
         result.error[:status_code].must_equal(400)
       end
@@ -39,7 +39,7 @@ describe CandyCheck::PlayStore::Acknowledger do
         result = subject.acknowledge_product_purchase(package_name: package_name, product_id: product_id, token: token)
 
         result.must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
-        result.acknowledged?.must_be_false
+        _(result.acknowledged?).must_be_false
         result.error[:body].must_equal(error_body)
         result.error[:status_code].must_equal(400)
       end

--- a/spec/play_store/acknowledger_spec.rb
+++ b/spec/play_store/acknowledger_spec.rb
@@ -17,7 +17,7 @@ describe CandyCheck::PlayStore::Acknowledger do
 
         _(result).must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
         _(result.acknowledged?).must_be_true
-        result.error.must_be_nil
+        _(result.error).must_be_nil
       end
     end
     it "when already acknowledged" do

--- a/spec/play_store/acknowledger_spec.rb
+++ b/spec/play_store/acknowledger_spec.rb
@@ -28,8 +28,8 @@ describe CandyCheck::PlayStore::Acknowledger do
 
         _(result).must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
         _(result.acknowledged?).must_be_false
-        result.error[:body].must_equal(error_body)
-        result.error[:status_code].must_equal(400)
+        _(result.error[:body]).must_equal(error_body)
+        _(result.error[:status_code]).must_equal(400)
       end
     end
     it "when it has been refunded" do
@@ -40,8 +40,8 @@ describe CandyCheck::PlayStore::Acknowledger do
 
         _(result).must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
         _(result.acknowledged?).must_be_false
-        result.error[:body].must_equal(error_body)
-        result.error[:status_code].must_equal(400)
+        _(result.error[:body]).must_equal(error_body)
+        _(result.error[:status_code]).must_equal(400)
       end
     end
   end

--- a/spec/play_store/acknowledger_spec.rb
+++ b/spec/play_store/acknowledger_spec.rb
@@ -15,7 +15,7 @@ describe CandyCheck::PlayStore::Acknowledger do
       VCR.use_cassette("play_store/product_acknowledgements/acknowledged") do
         result = subject.acknowledge_product_purchase(package_name: package_name, product_id: product_id, token: token)
 
-        result.must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
+        _(result).must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
         _(result.acknowledged?).must_be_true
         result.error.must_be_nil
       end
@@ -26,7 +26,7 @@ describe CandyCheck::PlayStore::Acknowledger do
       VCR.use_cassette("play_store/product_acknowledgements/already_acknowledged") do
         result = subject.acknowledge_product_purchase(package_name: package_name, product_id: product_id, token: token)
 
-        result.must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
+        _(result).must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
         _(result.acknowledged?).must_be_false
         result.error[:body].must_equal(error_body)
         result.error[:status_code].must_equal(400)
@@ -38,7 +38,7 @@ describe CandyCheck::PlayStore::Acknowledger do
       VCR.use_cassette("play_store/product_acknowledgements/refunded") do
         result = subject.acknowledge_product_purchase(package_name: package_name, product_id: product_id, token: token)
 
-        result.must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
+        _(result).must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
         _(result.acknowledged?).must_be_false
         result.error[:body].must_equal(error_body)
         result.error[:status_code].must_equal(400)

--- a/spec/play_store/product_acknowledgements/acknowledgement_spec.rb
+++ b/spec/play_store/product_acknowledgements/acknowledgement_spec.rb
@@ -21,7 +21,7 @@ describe CandyCheck::PlayStore::ProductAcknowledgements::Acknowledgement do
       VCR.use_cassette("play_store/product_acknowledgements/acknowledged") do
         result = subject.call!
 
-        result.must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
+        _(result).must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
         _(result.acknowledged?).must_be_true
         result.error.must_be_nil
       end
@@ -32,7 +32,7 @@ describe CandyCheck::PlayStore::ProductAcknowledgements::Acknowledgement do
       VCR.use_cassette("play_store/product_acknowledgements/already_acknowledged") do
         result = subject.call!
 
-        result.must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
+        _(result).must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
         _(result.acknowledged?).must_be_false
         result.error[:body].must_equal(error_body)
         result.error[:status_code].must_equal(400)
@@ -44,7 +44,7 @@ describe CandyCheck::PlayStore::ProductAcknowledgements::Acknowledgement do
       VCR.use_cassette("play_store/product_acknowledgements/refunded") do
         result = subject.call!
 
-        result.must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
+        _(result).must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
         _(result.acknowledged?).must_be_false
         result.error[:body].must_equal(error_body)
         result.error[:status_code].must_equal(400)

--- a/spec/play_store/product_acknowledgements/acknowledgement_spec.rb
+++ b/spec/play_store/product_acknowledgements/acknowledgement_spec.rb
@@ -23,7 +23,7 @@ describe CandyCheck::PlayStore::ProductAcknowledgements::Acknowledgement do
 
         _(result).must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
         _(result.acknowledged?).must_be_true
-        result.error.must_be_nil
+        _(result.error).must_be_nil
       end
     end
     it "when already acknowledged" do

--- a/spec/play_store/product_acknowledgements/acknowledgement_spec.rb
+++ b/spec/play_store/product_acknowledgements/acknowledgement_spec.rb
@@ -22,7 +22,7 @@ describe CandyCheck::PlayStore::ProductAcknowledgements::Acknowledgement do
         result = subject.call!
 
         result.must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
-        result.acknowledged?.must_be_true
+        _(result.acknowledged?).must_be_true
         result.error.must_be_nil
       end
     end

--- a/spec/play_store/product_acknowledgements/acknowledgement_spec.rb
+++ b/spec/play_store/product_acknowledgements/acknowledgement_spec.rb
@@ -34,8 +34,8 @@ describe CandyCheck::PlayStore::ProductAcknowledgements::Acknowledgement do
 
         _(result).must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
         _(result.acknowledged?).must_be_false
-        result.error[:body].must_equal(error_body)
-        result.error[:status_code].must_equal(400)
+        _(result.error[:body]).must_equal(error_body)
+        _(result.error[:status_code]).must_equal(400)
       end
     end
     it "when it has been refunded" do
@@ -46,8 +46,8 @@ describe CandyCheck::PlayStore::ProductAcknowledgements::Acknowledgement do
 
         _(result).must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
         _(result.acknowledged?).must_be_false
-        result.error[:body].must_equal(error_body)
-        result.error[:status_code].must_equal(400)
+        _(result.error[:body]).must_equal(error_body)
+        _(result.error[:status_code]).must_equal(400)
       end
     end
   end

--- a/spec/play_store/product_acknowledgements/acknowledgement_spec.rb
+++ b/spec/play_store/product_acknowledgements/acknowledgement_spec.rb
@@ -33,7 +33,7 @@ describe CandyCheck::PlayStore::ProductAcknowledgements::Acknowledgement do
         result = subject.call!
 
         result.must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
-        result.acknowledged?.must_be_false
+        _(result.acknowledged?).must_be_false
         result.error[:body].must_equal(error_body)
         result.error[:status_code].must_equal(400)
       end
@@ -45,7 +45,7 @@ describe CandyCheck::PlayStore::ProductAcknowledgements::Acknowledgement do
         result = subject.call!
 
         result.must_be_instance_of CandyCheck::PlayStore::ProductAcknowledgements::Response
-        result.acknowledged?.must_be_false
+        _(result.acknowledged?).must_be_false
         result.error[:body].must_equal(error_body)
         result.error[:status_code].must_equal(400)
       end

--- a/spec/play_store/product_acknowledgements/response_spec.rb
+++ b/spec/play_store/product_acknowledgements/response_spec.rb
@@ -47,8 +47,8 @@ describe CandyCheck::PlayStore::ProductAcknowledgements::Response do
       it 'returns the expected data' do
         result = subject.error
 
-        result[:status_code].must_equal(400)
-        result[:body].must_equal('A String describing the issue')
+        _(result[:status_code]).must_equal(400)
+        _(result[:body]).must_equal('A String describing the issue')
       end
     end
 

--- a/spec/play_store/product_acknowledgements/response_spec.rb
+++ b/spec/play_store/product_acknowledgements/response_spec.rb
@@ -24,7 +24,7 @@ describe CandyCheck::PlayStore::ProductAcknowledgements::Response do
       it 'returns false' do
         result = subject.acknowledged?
 
-        result.must_be_false
+        _(result).must_be_false
       end
     end
   end

--- a/spec/play_store/product_acknowledgements/response_spec.rb
+++ b/spec/play_store/product_acknowledgements/response_spec.rb
@@ -13,7 +13,7 @@ describe CandyCheck::PlayStore::ProductAcknowledgements::Response do
       it 'returns true' do
         result = subject.acknowledged?
 
-        result.must_be_true
+        _(result).must_be_true
       end
     end
 

--- a/spec/play_store/product_acknowledgements/response_spec.rb
+++ b/spec/play_store/product_acknowledgements/response_spec.rb
@@ -59,7 +59,7 @@ describe CandyCheck::PlayStore::ProductAcknowledgements::Response do
       it 'returns false' do
         result = subject.error
 
-        result.must_be_nil
+        _(result).must_be_nil
       end
     end
   end

--- a/spec/play_store/product_purchases/product_purchase_spec.rb
+++ b/spec/play_store/product_purchases/product_purchase_spec.rb
@@ -24,28 +24,28 @@ describe CandyCheck::PlayStore::ProductPurchases::ProductPurchase do
     end
 
     it "returns the purchase_state" do
-      subject.purchase_state.must_equal 0
+      _(subject.purchase_state).must_equal 0
     end
 
     it "returns the consumption_state" do
-      subject.consumption_state.must_equal 0
+      _(subject.consumption_state).must_equal 0
     end
 
     it "returns the developer_payload" do
-      subject.developer_payload.must_equal "payload that gets stored and returned"
+      _(subject.developer_payload).must_equal "payload that gets stored and returned"
     end
 
     it "returns the kind" do
-      subject.kind.must_equal "androidpublisher#productPurchase"
+      _(subject.kind).must_equal "androidpublisher#productPurchase"
     end
 
     it "returns the purchase_time_millis" do
-      subject.purchase_time_millis.must_equal 1_421_676_237_413
+      _(subject.purchase_time_millis).must_equal 1_421_676_237_413
     end
 
     it "returns the purchased_at" do
       expected = DateTime.new(2015, 1, 19, 14, 3, 57)
-      subject.purchased_at.must_equal expected
+      _(subject.purchased_at).must_equal expected
     end
   end
 

--- a/spec/play_store/product_purchases/product_purchase_spec.rb
+++ b/spec/play_store/product_purchases/product_purchase_spec.rb
@@ -20,7 +20,7 @@ describe CandyCheck::PlayStore::ProductPurchases::ProductPurchase do
     end
 
     it "is not consumed" do
-      subject.consumed?.must_be_false
+      _(subject.consumed?).must_be_false
     end
 
     it "returns the purchase_state" do
@@ -83,7 +83,7 @@ describe CandyCheck::PlayStore::ProductPurchases::ProductPurchase do
     end
 
     it "is valid?" do
-      subject.valid?.must_be_false
+      _(subject.valid?).must_be_false
     end
   end
 

--- a/spec/play_store/product_purchases/product_purchase_spec.rb
+++ b/spec/play_store/product_purchases/product_purchase_spec.rb
@@ -16,7 +16,7 @@ describe CandyCheck::PlayStore::ProductPurchases::ProductPurchase do
     end
 
     it "is valid?" do
-      subject.valid?.must_be_true
+      _(subject.valid?).must_be_true
     end
 
     it "is not consumed" do
@@ -62,11 +62,11 @@ describe CandyCheck::PlayStore::ProductPurchases::ProductPurchase do
     end
 
     it "is valid?" do
-      subject.valid?.must_be_true
+      _(subject.valid?).must_be_true
     end
 
     it "is consumed?" do
-      subject.consumed?.must_be_true
+      _(subject.consumed?).must_be_true
     end
   end
 

--- a/spec/play_store/product_purchases/product_verification_spec.rb
+++ b/spec/play_store/product_purchases/product_verification_spec.rb
@@ -22,7 +22,7 @@ describe CandyCheck::PlayStore::ProductPurchases::ProductVerification do
         result = subject.call!
         result.must_be_instance_of CandyCheck::PlayStore::ProductPurchases::ProductPurchase
         result.valid?.must_be_true
-        result.consumed?.must_be_false
+        _(result.consumed?).must_be_false
       end
     end
   end

--- a/spec/play_store/product_purchases/product_verification_spec.rb
+++ b/spec/play_store/product_purchases/product_verification_spec.rb
@@ -20,7 +20,7 @@ describe CandyCheck::PlayStore::ProductPurchases::ProductVerification do
     it "returns a product purchase" do
       VCR.use_cassette("play_store/product_purchases/valid_but_not_consumed") do
         result = subject.call!
-        result.must_be_instance_of CandyCheck::PlayStore::ProductPurchases::ProductPurchase
+        _(result).must_be_instance_of CandyCheck::PlayStore::ProductPurchases::ProductPurchase
         _(result.valid?).must_be_true
         _(result.consumed?).must_be_false
       end
@@ -31,7 +31,7 @@ describe CandyCheck::PlayStore::ProductPurchases::ProductVerification do
     it "returns a verification failure" do
       VCR.use_cassette("play_store/product_purchases/permission_denied") do
         result = subject.call!
-        result.must_be_instance_of CandyCheck::PlayStore::VerificationFailure
+        _(result).must_be_instance_of CandyCheck::PlayStore::VerificationFailure
         result.code.must_equal 401
       end
     end
@@ -41,7 +41,7 @@ describe CandyCheck::PlayStore::ProductPurchases::ProductVerification do
     it "returns a verification failure" do
       VCR.use_cassette("play_store/product_purchases/response_with_empty_body") do
         result = subject.call!
-        result.must_be_instance_of CandyCheck::PlayStore::VerificationFailure
+        _(result).must_be_instance_of CandyCheck::PlayStore::VerificationFailure
         result.code.must_equal(-1)
       end
     end

--- a/spec/play_store/product_purchases/product_verification_spec.rb
+++ b/spec/play_store/product_purchases/product_verification_spec.rb
@@ -32,7 +32,7 @@ describe CandyCheck::PlayStore::ProductPurchases::ProductVerification do
       VCR.use_cassette("play_store/product_purchases/permission_denied") do
         result = subject.call!
         _(result).must_be_instance_of CandyCheck::PlayStore::VerificationFailure
-        result.code.must_equal 401
+        _(result.code).must_equal 401
       end
     end
   end
@@ -42,7 +42,7 @@ describe CandyCheck::PlayStore::ProductPurchases::ProductVerification do
       VCR.use_cassette("play_store/product_purchases/response_with_empty_body") do
         result = subject.call!
         _(result).must_be_instance_of CandyCheck::PlayStore::VerificationFailure
-        result.code.must_equal(-1)
+        _(result.code).must_equal(-1)
       end
     end
   end

--- a/spec/play_store/product_purchases/product_verification_spec.rb
+++ b/spec/play_store/product_purchases/product_verification_spec.rb
@@ -21,7 +21,7 @@ describe CandyCheck::PlayStore::ProductPurchases::ProductVerification do
       VCR.use_cassette("play_store/product_purchases/valid_but_not_consumed") do
         result = subject.call!
         result.must_be_instance_of CandyCheck::PlayStore::ProductPurchases::ProductPurchase
-        result.valid?.must_be_true
+        _(result.valid?).must_be_true
         _(result.consumed?).must_be_false
       end
     end

--- a/spec/play_store/subscription_purchases/subscription_purchase_spec.rb
+++ b/spec/play_store/subscription_purchases/subscription_purchase_spec.rb
@@ -33,7 +33,7 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase do
     end
 
     it "checks that auto renewal status is false" do
-      subject.auto_renewing?.must_be_false
+      _(subject.auto_renewing?).must_be_false
     end
 
     it "returns the developer_payload" do
@@ -79,7 +79,7 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase do
     end
 
     it "is expired?" do
-      subject.expired?.must_be_false
+      _(subject.expired?).must_be_false
     end
 
     it "is two days left until it is overdue" do
@@ -123,7 +123,7 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase do
       end
 
       it "is not canceled?" do
-        subject.canceled_by_user?.must_be_false
+        _(subject.canceled_by_user?).must_be_false
       end
 
       it "returns nil user_cancellation_time_millis" do

--- a/spec/play_store/subscription_purchases/subscription_purchase_spec.rb
+++ b/spec/play_store/subscription_purchases/subscription_purchase_spec.rb
@@ -25,7 +25,7 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase do
     end
 
     it "returns the payment_state" do
-      subject.payment_state.must_equal 1
+      _(subject.payment_state).must_equal 1
     end
 
     it "considers a payment as valid" do
@@ -37,30 +37,30 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase do
     end
 
     it "returns the developer_payload" do
-      subject.developer_payload.must_equal \
+      _(subject.developer_payload).must_equal \
         "payload that gets stored and returned"
     end
 
     it "returns the kind" do
-      subject.kind.must_equal "androidpublisher#subscriptionPurchase"
+      _(subject.kind).must_equal "androidpublisher#subscriptionPurchase"
     end
 
     it "returns the start_time_millis" do
-      subject.start_time_millis.must_equal 145_954_011_324_4
+      _(subject.start_time_millis).must_equal 145_954_011_324_4
     end
 
     it "returns the expiry_time_millis" do
-      subject.expiry_time_millis.must_equal 146_213_208_861_0
+      _(subject.expiry_time_millis).must_equal 146_213_208_861_0
     end
 
     it "returns the starts_at" do
       expected = DateTime.new(2016, 4, 1, 19, 48, 33)
-      subject.starts_at.must_equal expected
+      _(subject.starts_at).must_equal expected
     end
 
     it "returns the expires_at" do
       expected = DateTime.new(2016, 5, 1, 19, 48, 8)
-      subject.expires_at.must_equal expected
+      _(subject.expires_at).must_equal expected
     end
   end
 
@@ -83,7 +83,7 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase do
     end
 
     it "is two days left until it is overdue" do
-      subject.overdue_days.must_equal(-2)
+      _(subject.overdue_days).must_equal(-2)
     end
   end
 
@@ -154,12 +154,12 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase do
       end
 
       it "returns the user_cancellation_time_millis" do
-        subject.user_cancellation_time_millis.must_equal 1_461_872_888_000
+        _(subject.user_cancellation_time_millis).must_equal 1_461_872_888_000
       end
 
       it "returns the starts_at" do
         expected = DateTime.new(2016, 4, 28, 19, 48, 8)
-        subject.canceled_at.must_equal expected
+        _(subject.canceled_at).must_equal expected
       end
     end
   end
@@ -206,7 +206,7 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase do
     end
 
     it "returns the price_currency_code" do
-      subject.price_currency_code.must_equal "SOMECODE"
+      _(subject.price_currency_code).must_equal "SOMECODE"
     end
   end
 

--- a/spec/play_store/subscription_purchases/subscription_purchase_spec.rb
+++ b/spec/play_store/subscription_purchases/subscription_purchase_spec.rb
@@ -127,11 +127,11 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase do
       end
 
       it "returns nil user_cancellation_time_millis" do
-        subject.user_cancellation_time_millis.must_be_nil
+        _(subject.user_cancellation_time_millis).must_be_nil
       end
 
       it "returns nil canceled_at" do
-        subject.canceled_at.must_be_nil
+        _(subject.canceled_at).must_be_nil
       end
     end
 

--- a/spec/play_store/subscription_purchases/subscription_purchase_spec.rb
+++ b/spec/play_store/subscription_purchases/subscription_purchase_spec.rb
@@ -17,11 +17,11 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase do
     end
 
     it "is expired?" do
-      subject.expired?.must_be_true
+      _(subject.expired?).must_be_true
     end
 
     it "is canceled by user" do
-      subject.canceled_by_user?.must_be_true
+      _(subject.canceled_by_user?).must_be_true
     end
 
     it "returns the payment_state" do
@@ -29,7 +29,7 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase do
     end
 
     it "considers a payment as valid" do
-      subject.payment_received?.must_be_true
+      _(subject.payment_received?).must_be_true
     end
 
     it "checks that auto renewal status is false" do
@@ -101,11 +101,11 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase do
     end
 
     it "is expired?" do
-      subject.expired?.must_be_true
+      _(subject.expired?).must_be_true
     end
 
     it "is payment_failed?" do
-      subject.payment_failed?.must_be_true
+      _(subject.payment_failed?).must_be_true
     end
   end
 
@@ -150,7 +150,7 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase do
       end
 
       it "is canceled?" do
-        subject.canceled_by_user?.must_be_true
+        _(subject.canceled_by_user?).must_be_true
       end
 
       it "returns the user_cancellation_time_millis" do
@@ -178,11 +178,11 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase do
     end
 
     it "is expired?" do
-      subject.expired?.must_be_true
+      _(subject.expired?).must_be_true
     end
 
     it "is payment_pending?" do
-      subject.payment_pending?.must_be_true
+      _(subject.payment_pending?).must_be_true
     end
   end
 
@@ -202,7 +202,7 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase do
     end
 
     it "is trial?" do
-      subject.trial?.must_be_true
+      _(subject.trial?).must_be_true
     end
 
     it "returns the price_currency_code" do

--- a/spec/play_store/subscription_purchases/subscription_verification_spec.rb
+++ b/spec/play_store/subscription_purchases/subscription_verification_spec.rb
@@ -22,7 +22,7 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionVerification 
       VCR.use_cassette("play_store/subscription_purchases/valid_but_expired") do
         result = subject.call!
 
-        result.must_be_instance_of CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase
+        _(result).must_be_instance_of CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase
         _(result.expired?).must_be_true
       end
     end
@@ -32,7 +32,7 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionVerification 
     it "returns a verification failure" do
       VCR.use_cassette("play_store/subscription_purchases/permission_denied") do
         result = subject.call!
-        result.must_be_instance_of CandyCheck::PlayStore::VerificationFailure
+        _(result).must_be_instance_of CandyCheck::PlayStore::VerificationFailure
         result.code.must_equal 401
       end
     end
@@ -45,7 +45,7 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionVerification 
 
     it "returns a verification failure" do
       result = subject.call!
-      result.must_be_instance_of CandyCheck::PlayStore::VerificationFailure
+      _(result).must_be_instance_of CandyCheck::PlayStore::VerificationFailure
       result.code.must_equal(-1)
     end
   end
@@ -59,7 +59,7 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionVerification 
 
     it "returns a verification failure" do
       result = subject.call!
-      result.must_be_instance_of CandyCheck::PlayStore::VerificationFailure
+      _(result).must_be_instance_of CandyCheck::PlayStore::VerificationFailure
     end
   end
 end

--- a/spec/play_store/subscription_purchases/subscription_verification_spec.rb
+++ b/spec/play_store/subscription_purchases/subscription_verification_spec.rb
@@ -23,7 +23,7 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionVerification 
         result = subject.call!
 
         result.must_be_instance_of CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase
-        result.expired?.must_be_true
+        _(result.expired?).must_be_true
       end
     end
   end

--- a/spec/play_store/subscription_purchases/subscription_verification_spec.rb
+++ b/spec/play_store/subscription_purchases/subscription_verification_spec.rb
@@ -33,7 +33,7 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionVerification 
       VCR.use_cassette("play_store/subscription_purchases/permission_denied") do
         result = subject.call!
         _(result).must_be_instance_of CandyCheck::PlayStore::VerificationFailure
-        result.code.must_equal 401
+        _(result.code).must_equal 401
       end
     end
   end
@@ -46,7 +46,7 @@ describe CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionVerification 
     it "returns a verification failure" do
       result = subject.call!
       _(result).must_be_instance_of CandyCheck::PlayStore::VerificationFailure
-      result.code.must_equal(-1)
+      _(result.code).must_equal(-1)
     end
   end
 

--- a/spec/play_store/verification_failure_spec.rb
+++ b/spec/play_store/verification_failure_spec.rb
@@ -9,11 +9,11 @@ describe CandyCheck::PlayStore::VerificationFailure do
     end
 
     it "returns the code" do
-      subject.code.must_equal 401
+      _(subject.code).must_equal 401
     end
 
     it "returns the message" do
-      subject.message.must_equal "The current user has insufficient permissions"
+      _(subject.message).must_equal "The current user has insufficient permissions"
     end
   end
 
@@ -23,11 +23,11 @@ describe CandyCheck::PlayStore::VerificationFailure do
     end
 
     it "returns an unknown code" do
-      subject.code.must_equal(-1)
+      _(subject.code).must_equal(-1)
     end
 
     it "returns an unknown message" do
-      subject.message.must_equal "Unknown error"
+      _(subject.message).must_equal "Unknown error"
     end
   end
 

--- a/spec/play_store/verifier_spec.rb
+++ b/spec/play_store/verifier_spec.rb
@@ -16,7 +16,7 @@ describe CandyCheck::PlayStore::Verifier do
       VCR.use_cassette("play_store/product_purchases/valid_but_not_consumed") do
         result = subject.verify_product_purchase(package_name: package_name, product_id: product_id, token: token)
         result.must_be_instance_of CandyCheck::PlayStore::ProductPurchases::ProductPurchase
-        result.valid?.must_be_true
+        _(result.valid?).must_be_true
         _(result.consumed?).must_be_false
       end
     end

--- a/spec/play_store/verifier_spec.rb
+++ b/spec/play_store/verifier_spec.rb
@@ -17,7 +17,7 @@ describe CandyCheck::PlayStore::Verifier do
         result = subject.verify_product_purchase(package_name: package_name, product_id: product_id, token: token)
         result.must_be_instance_of CandyCheck::PlayStore::ProductPurchases::ProductPurchase
         result.valid?.must_be_true
-        result.consumed?.must_be_false
+        _(result.consumed?).must_be_false
       end
     end
 

--- a/spec/play_store/verifier_spec.rb
+++ b/spec/play_store/verifier_spec.rb
@@ -15,7 +15,7 @@ describe CandyCheck::PlayStore::Verifier do
     it "verifies a product purchase" do
       VCR.use_cassette("play_store/product_purchases/valid_but_not_consumed") do
         result = subject.verify_product_purchase(package_name: package_name, product_id: product_id, token: token)
-        result.must_be_instance_of CandyCheck::PlayStore::ProductPurchases::ProductPurchase
+        _(result).must_be_instance_of CandyCheck::PlayStore::ProductPurchases::ProductPurchase
         _(result.valid?).must_be_true
         _(result.consumed?).must_be_false
       end
@@ -24,7 +24,7 @@ describe CandyCheck::PlayStore::Verifier do
     it "can return a product purchase verification failure" do
       VCR.use_cassette("play_store/product_purchases/permission_denied") do
         result = subject.verify_product_purchase(package_name: package_name, product_id: product_id, token: token)
-        result.must_be_instance_of CandyCheck::PlayStore::VerificationFailure
+        _(result).must_be_instance_of CandyCheck::PlayStore::VerificationFailure
       end
     end
   end
@@ -33,14 +33,14 @@ describe CandyCheck::PlayStore::Verifier do
     it "verifies a subscription purchase" do
       VCR.use_cassette("play_store/subscription_purchases/valid_but_expired") do
         result = subject.verify_subscription_purchase(package_name: package_name, subscription_id: subscription_id, token: token)
-        result.must_be_instance_of CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase
+        _(result).must_be_instance_of CandyCheck::PlayStore::SubscriptionPurchases::SubscriptionPurchase
       end
     end
 
     it "can return a subscription purchase verification failure" do
       VCR.use_cassette("play_store/subscription_purchases/permission_denied") do
         result = subject.verify_subscription_purchase(package_name: package_name, subscription_id: subscription_id, token: token)
-        result.must_be_instance_of CandyCheck::PlayStore::VerificationFailure
+        _(result).must_be_instance_of CandyCheck::PlayStore::VerificationFailure
       end
     end
   end

--- a/spec/support/with_command.rb
+++ b/spec/support/with_command.rb
@@ -26,8 +26,5 @@ module WithCommand
       lines << object
     end
 
-    def must_be(*expected)
-      lines.must_equal expected
-    end
   end
 end


### PR DESCRIPTION
There are too many warnings like following when running test. It is so noisy.

```
DEPRECATED: global use of must_be from spec/cli/commands/version_spec.rb:9. Use _(obj).must_be instead. This will fail in Minitest 6.
```

In this PR, resolve the similar warnings.