### PR TITLE
Update thor

### DIFF
--- a/candy_check.gemspec
+++ b/candy_check.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "google-api-client", "~> 0.43.0"
   spec.add_dependency "multi_json", "~> 1.10"
-  spec.add_dependency "thor", "~> 0.19"
+  spec.add_dependency "thor", "< 2.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "coveralls", "~> 0.8"

--- a/lib/candy_check/cli/app.rb
+++ b/lib/candy_check/cli/app.rb
@@ -40,6 +40,10 @@ module CandyCheck
       def version
         Commands::Version.run
       end
+
+      def self.exit_on_failure?
+        true
+      end
     end
   end
 end

--- a/spec/cli/app_spec.rb
+++ b/spec/cli/app_spec.rb
@@ -24,6 +24,10 @@ describe CandyCheck::CLI::App do
     end
   end
 
+  it 'returns true when call .exit_on_failure?' do
+    _(CandyCheck::CLI::App.exit_on_failure?).must_equal true
+  end
+
   private
 
   def stub_command(target)


### PR DESCRIPTION
Our project need [thor](https://github.com/erikhuda/thor) to be version 1 or later to install by other dependencies.
This PR will be update the gem.

- 2fdb8f8

Update gem

- 5215359

Thor shows warning when command line exit with error.
Implement class method to resolve.

```console
$ ./bin/candy_check foo
Could not find command "foo".
Deprecation warning: Thor exit with status 0 on errors. To keep this behavior, you must define `exit_on_failure?` in `CandyCheck::CLI::App`
You can silence deprecations warning by setting the environment variable THOR_SILENCE_DEPRECATION.
```

@jnbt Please look this 😉 