### PR TITLE
Replace Google API client with specific gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 2.6.5
-  - 2.5.7
+  - 2.7.3
+  - 2.6.7
+  - 2.5.9
   - jruby-9.2.9.0
   - ruby-head
   - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
-sudo: false
+os: linux
+dist: xenial
 cache: bundler
 rvm:
   - 2.7.3
@@ -8,7 +9,7 @@ rvm:
   - jruby-9.2.9.0
   - ruby-head
   - jruby-head
-matrix:
+jobs:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: bundler
 rvm:
   - 2.6.5
   - 2.5.7
-  - 2.4.9
   - jruby-9.2.9.0
   - ruby-head
   - jruby-head

--- a/candy_check.gemspec
+++ b/candy_check.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new(">= 2.4")
 
-  spec.add_dependency "google-api-client", "~> 0.43.0"
+  spec.add_dependency "google-apis-androidpublisher_v3", "~> 0.2.0"
+  spec.add_dependency "googleauth", "~> 0.16"
   spec.add_dependency "multi_json", "~> 1.10"
   spec.add_dependency "thor", "< 2.0"
 

--- a/candy_check.gemspec
+++ b/candy_check.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.4")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5")
 
   spec.add_dependency "google-apis-androidpublisher_v3", "~> 0.2.0"
   spec.add_dependency "googleauth", "~> 0.16"

--- a/lib/candy_check/play_store.rb
+++ b/lib/candy_check/play_store.rb
@@ -1,4 +1,5 @@
-require "google/apis/androidpublisher_v3"
+require "google-apis-androidpublisher_v3"
+require "googleauth"
 
 require "candy_check/play_store/android_publisher_service"
 require "candy_check/play_store/product_purchases/product_purchase"

--- a/spec/fixtures/vcr_cassettes/play_store/product_acknowledgements/acknowledged.yml
+++ b/spec/fixtures/vcr_cassettes/play_store/product_acknowledgements/acknowledged.yml
@@ -51,7 +51,7 @@ http_interactions:
   recorded_at: Mon, 22 Jun 2020 11:38:56 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/androidpublisher/v3/applications/fake_package_name/purchases/products/fake_product_id/tokens/fake_token:acknowledge
+    uri: https://androidpublisher.googleapis.com/androidpublisher/v3/applications/fake_package_name/purchases/products/fake_product_id/tokens/fake_token:acknowledge
     body:
       encoding: UTF-8
       string: ''

--- a/spec/fixtures/vcr_cassettes/play_store/product_acknowledgements/already_acknowledged.yml
+++ b/spec/fixtures/vcr_cassettes/play_store/product_acknowledgements/already_acknowledged.yml
@@ -51,7 +51,7 @@ http_interactions:
   recorded_at: Mon, 22 Jun 2020 13:11:45 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/androidpublisher/v3/applications/fake_package_name/purchases/products/fake_product_id/tokens/fake_token:acknowledge
+    uri: https://androidpublisher.googleapis.com/androidpublisher/v3/applications/fake_package_name/purchases/products/fake_product_id/tokens/fake_token:acknowledge
     body:
       encoding: UTF-8
       string: ''

--- a/spec/fixtures/vcr_cassettes/play_store/product_acknowledgements/refunded.yml
+++ b/spec/fixtures/vcr_cassettes/play_store/product_acknowledgements/refunded.yml
@@ -51,7 +51,7 @@ http_interactions:
   recorded_at: Mon, 22 Jun 2020 14:37:46 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/androidpublisher/v3/applications/fake_package_name/purchases/products/fake_product_id/tokens/fake_token:acknowledge
+    uri: https://androidpublisher.googleapis.com/androidpublisher/v3/applications/fake_package_name/purchases/products/fake_product_id/tokens/fake_token:acknowledge
     body:
       encoding: UTF-8
       string: ''

--- a/spec/fixtures/vcr_cassettes/play_store/product_purchases/permission_denied.yml
+++ b/spec/fixtures/vcr_cassettes/play_store/product_purchases/permission_denied.yml
@@ -55,7 +55,7 @@ http_interactions:
   recorded_at: Fri, 04 Oct 2019 13:11:23 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/androidpublisher/v3/applications/my_package_name/purchases/products/my_product_id/tokens/my_token
+    uri: https://androidpublisher.googleapis.com/androidpublisher/v3/applications/my_package_name/purchases/products/my_product_id/tokens/my_token
     body:
       encoding: UTF-8
       string: ''
@@ -125,7 +125,7 @@ http_interactions:
   recorded_at: Fri, 04 Oct 2019 13:11:24 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/androidpublisher/v3/applications/my_package_name/purchases/products/my_product_id/tokens/my_token
+    uri: https://androidpublisher.googleapis.com/androidpublisher/v3/applications/my_package_name/purchases/products/my_product_id/tokens/my_token
     body:
       encoding: UTF-8
       string: ''

--- a/spec/fixtures/vcr_cassettes/play_store/product_purchases/response_with_empty_body.yml
+++ b/spec/fixtures/vcr_cassettes/play_store/product_purchases/response_with_empty_body.yml
@@ -55,7 +55,7 @@ http_interactions:
   recorded_at: Fri, 04 Oct 2019 13:11:23 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/androidpublisher/v3/applications/my_package_name/purchases/products/my_product_id/tokens/my_token
+    uri: https://androidpublisher.googleapis.com/androidpublisher/v3/applications/my_package_name/purchases/products/my_product_id/tokens/my_token
     body:
       encoding: UTF-8
       string: ''
@@ -125,7 +125,7 @@ http_interactions:
   recorded_at: Fri, 04 Oct 2019 13:11:24 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/androidpublisher/v3/applications/my_package_name/purchases/products/my_product_id/tokens/my_token
+    uri: https://androidpublisher.googleapis.com/androidpublisher/v3/applications/my_package_name/purchases/products/my_product_id/tokens/my_token
     body:
       encoding: UTF-8
       string: ''

--- a/spec/fixtures/vcr_cassettes/play_store/product_purchases/valid_but_not_consumed.yml
+++ b/spec/fixtures/vcr_cassettes/play_store/product_purchases/valid_but_not_consumed.yml
@@ -55,7 +55,7 @@ http_interactions:
   recorded_at: Fri, 04 Oct 2019 09:25:53 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/androidpublisher/v3/applications/my_package_name/purchases/products/my_product_id/tokens/my_token
+    uri: https://androidpublisher.googleapis.com/androidpublisher/v3/applications/my_package_name/purchases/products/my_product_id/tokens/my_token
     body:
       encoding: UTF-8
       string: ''

--- a/spec/fixtures/vcr_cassettes/play_store/subscription_purchases/permission_denied.yml
+++ b/spec/fixtures/vcr_cassettes/play_store/subscription_purchases/permission_denied.yml
@@ -55,7 +55,7 @@ http_interactions:
   recorded_at: Thu, 10 Oct 2019 14:07:52 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/androidpublisher/v3/applications/my_package_name/purchases/subscriptions/my_subscription_id/tokens/my_token
+    uri: https://androidpublisher.googleapis.com/androidpublisher/v3/applications/my_package_name/purchases/subscriptions/my_subscription_id/tokens/my_token
     body:
       encoding: UTF-8
       string: ''
@@ -125,7 +125,7 @@ http_interactions:
   recorded_at: Thu, 10 Oct 2019 14:07:52 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/androidpublisher/v3/applications/my_package_name/purchases/subscriptions/my_subscription_id/tokens/my_token
+    uri: https://androidpublisher.googleapis.com/androidpublisher/v3/applications/my_package_name/purchases/subscriptions/my_subscription_id/tokens/my_token
     body:
       encoding: UTF-8
       string: ''

--- a/spec/fixtures/vcr_cassettes/play_store/subscription_purchases/valid_but_expired.yml
+++ b/spec/fixtures/vcr_cassettes/play_store/subscription_purchases/valid_but_expired.yml
@@ -55,7 +55,7 @@ http_interactions:
   recorded_at: Thu, 24 Oct 2019 10:43:13 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/androidpublisher/v3/applications/my_package_name/purchases/subscriptions/my_subscription_id/tokens/my_token
+    uri: https://androidpublisher.googleapis.com/androidpublisher/v3/applications/my_package_name/purchases/subscriptions/my_subscription_id/tokens/my_token
     body:
       encoding: UTF-8
       string: ''


### PR DESCRIPTION
As explained in their [docs]( https://github.com/googleapis/google-api-ruby-client/blob/master/google-api-client/OVERVIEW.md) Google changed their approach managing their services gems and the global `google-api-client` is deprecated.

> This library is deprecated and will likely not be updated further. Instead, please install the gem corresponding to the specific service you want to use. For example, to use the Google Drive V3 client, install the google-apis-drive_v3 gem. To use the code generator, install the google-apis-generator gem.
> The `google-api-client` gem is a 75 megabyte installation including client classes for more than 300 services. Although the library is designed so that only the classes being used are loaded into memory, it still takes a nontrivial amount of space on disk (and in deployments), and can take a while to install.

Here we only need access to the Android Publisher and the Auth ones, replacing the global one.

This change enables also the support for Ruby 3.0, so it fixes #64.